### PR TITLE
conn/bind_tcp: merge two writes in Send into one vectored write

### DIFF
--- a/conn/bind_tcp.go
+++ b/conn/bind_tcp.go
@@ -196,11 +196,8 @@ func (t *TcpBind) Send(bufs [][]byte, endpoint Endpoint) error {
 	for _, buf := range bufs {
 		var l reqLen
 		l.FromLen(len(buf))
-		_, err := conn.Write(l[:])
-		if err != nil {
-			return err
-		}
-		_, err = conn.Write(buf)
+		b := net.Buffers{l[:], buf}
+		_, err := b.WriteTo(conn)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Replace the separate  calls for the 4-byte length header and the payload with a single , reducing syscalls and avoiding potential interleaving issues.