### PR TITLE
conn/bind_tcp, libwg, tun/netstack: make TCP congestion control configurable

### DIFF
--- a/conn/bind_tcp.go
+++ b/conn/bind_tcp.go
@@ -1,11 +1,13 @@
 package conn
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/netip"
 	"runtime"
 	"sync"
+	"syscall"
 
 	"golang.zx2c4.com/wireguard/common"
 )
@@ -35,9 +37,14 @@ type TcpBind struct {
 	tcpConnMap common.SyncMap[string, *net.TCPConn]
 	listener   *net.TCPListener
 
-	dataPool  sync.Pool
-	recvChan  chan *recvData
-	closeChan chan struct{}
+	dataPool   sync.Pool
+	recvChan   chan *recvData
+	closeChan  chan struct{}
+	congestion string
+}
+
+func (t *TcpBind) SetCongestionControl(cc string) {
+	t.congestion = cc
 }
 
 type reqLen [4]byte
@@ -133,13 +140,22 @@ func (t *TcpBind) Open(port uint16) (fns []ReceiveFunc, actualPort uint16, err e
 	t.recvChan = make(chan *recvData)
 	t.closeChan = make(chan struct{})
 
-	t.listener, err = net.ListenTCP("tcp", &net.TCPAddr{Port: int(port)})
+	lc := net.ListenConfig{}
+	if t.congestion != "" {
+		lc.Control = func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				_ = setTCPCongestionControl(int(fd), t.congestion)
+			})
+		}
+	}
+	l, err := lc.Listen(context.Background(), "tcp", (&net.TCPAddr{Port: int(port)}).String())
 	if err != nil {
 		return nil, 0, err
 	}
+	t.listener = l.(*net.TCPListener)
 	go t.accept()
 	fn := t.makeReceive()
-	return []ReceiveFunc{fn}, port, nil
+	return []ReceiveFunc{fn}, uint16(t.listener.Addr().(*net.TCPAddr).Port), nil
 }
 
 func (t *TcpBind) Close() error {
@@ -179,10 +195,20 @@ func (t *TcpBind) getConn(endpoint Endpoint) (*net.TCPConn, error) {
 		IP:   ip,
 		Port: int(endpoint.(*StdNetEndpoint).Port()),
 	}
-	conn, err := net.DialTCP("tcp", nil, addr)
+
+	d := net.Dialer{}
+	if t.congestion != "" {
+		d.Control = func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				_ = setTCPCongestionControl(int(fd), t.congestion)
+			})
+		}
+	}
+	c, err := d.DialContext(context.Background(), "tcp", addr.String())
 	if err != nil {
 		return nil, err
 	}
+	conn = c.(*net.TCPConn)
 	t.handleConn(conn, endpoint)
 	t.tcpConnMap.Store(endpoint.DstToString(), conn)
 	return conn, nil

--- a/conn/bind_tcp_linux.go
+++ b/conn/bind_tcp_linux.go
@@ -1,0 +1,9 @@
+//go:build linux
+
+package conn
+
+import "golang.org/x/sys/unix"
+
+func setTCPCongestionControl(fd int, cc string) error {
+	return unix.SetsockoptString(fd, unix.IPPROTO_TCP, unix.TCP_CONGESTION, cc)
+}

--- a/conn/bind_tcp_other.go
+++ b/conn/bind_tcp_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package conn
+
+func setTCPCongestionControl(fd int, cc string) error {
+	return nil
+}

--- a/libwg/main.go
+++ b/libwg/main.go
@@ -92,9 +92,12 @@ func stopWg() {
 //	protocol:
 //	  0 for udp (default)
 //	  1 for tcp (default)
+//	congestionControl:
+//	  TCP congestion control algorithm name, e.g. "bbr", "cubic"
+//	  ignored when protocol is not tcp
 //
 //export startWg
-func startWg(logLevel, protocol C.int, interfaceName *C.cchar_t) C.int {
+func startWg(logLevel, protocol C.int, interfaceName, congestionControl *C.cchar_t) C.int {
 	name := C.GoString(interfaceName)
 	logger = device.NewLogger(
 		int(logLevel),
@@ -120,7 +123,11 @@ func startWg(logLevel, protocol C.int, interfaceName *C.cchar_t) C.int {
 	case 0:
 		wgDevice = device.NewDevice(tunDevice, conn.NewDefaultBind(), logger)
 	case 1:
-		wgDevice = device.NewDevice(tunDevice, conn.NewTCPBind(), logger)
+		tcpBind := conn.NewTCPBind().(*conn.TcpBind)
+		if cc := C.GoString(congestionControl); cc != "" {
+			tcpBind.SetCongestionControl(cc)
+		}
+		wgDevice = device.NewDevice(tunDevice, tcpBind, logger)
 	default:
 		logger.Errorf("Protocol %d not supported", protocol)
 		return ExitSetupFailed
@@ -167,16 +174,17 @@ func parseAddrList(s string) ([]netip.Addr, error) {
 // SOCKS5 proxy. Outbound connections accepted by the proxy are dialed through
 // the tunnel via tnet.DialContext.
 //
-//	protocol:    0 for udp (default), 1 for tcp
-//	addresses:   comma-separated interface IPs/CIDRs assigned by the server
-//	dnsServers:  comma-separated DNS server IPs (resolved inside the tunnel)
-//	socksListen: listen address for the SOCKS5 proxy, e.g. "0.0.0.0:1080"
-//	socksUser:   SOCKS5 username; empty disables authentication
-//	socksPass:   SOCKS5 password (used only when socksUser is non-empty)
-//	mtu:         interface MTU (<=0 uses the default)
+//	protocol:          0 for udp (default), 1 for tcp
+//	addresses:         comma-separated interface IPs/CIDRs assigned by the server
+//	dnsServers:        comma-separated DNS server IPs (resolved inside the tunnel)
+//	socksListen:       listen address for the SOCKS5 proxy, e.g. "0.0.0.0:1080"
+//	socksUser:         SOCKS5 username; empty disables authentication
+//	socksPass:         SOCKS5 password (used only when socksUser is non-empty)
+//	mtu:               interface MTU (<=0 uses the default)
+//	congestionControl: TCP congestion control algorithm name, ignored for udp
 //
 //export startWgNetstack
-func startWgNetstack(logLevel, protocol C.int, addresses, dnsServers, socksListen, socksUser, socksPass *C.cchar_t, mtu C.int) C.int {
+func startWgNetstack(logLevel, protocol C.int, addresses, dnsServers, socksListen, socksUser, socksPass, congestionControl *C.cchar_t, mtu C.int) C.int {
 	logger = device.NewLogger(int(logLevel), "wg-corplink(netstack) ")
 	logger.Verbosef("Starting wg-corplink version %s (netstack/socks5 mode)", Version)
 
@@ -200,7 +208,7 @@ func startWgNetstack(logLevel, protocol C.int, addresses, dnsServers, socksListe
 		m = device.DefaultMTU
 	}
 
-	tunDevice, netStack, err := netstack.CreateNetTUN(addrs, dns, m)
+	tunDevice, netStack, err := netstack.CreateNetTUNWithCC(addrs, dns, m, C.GoString(congestionControl))
 	if err != nil {
 		logger.Errorf("Failed to create netstack TUN device: %v", err)
 		return ExitSetupFailed
@@ -211,7 +219,11 @@ func startWgNetstack(logLevel, protocol C.int, addresses, dnsServers, socksListe
 	case 0:
 		wgDevice = device.NewDevice(tunDevice, conn.NewDefaultBind(), logger)
 	case 1:
-		wgDevice = device.NewDevice(tunDevice, conn.NewTCPBind(), logger)
+		tcpBind := conn.NewTCPBind().(*conn.TcpBind)
+		if cc := C.GoString(congestionControl); cc != "" {
+			tcpBind.SetCongestionControl(cc)
+		}
+		wgDevice = device.NewDevice(tunDevice, tcpBind, logger)
 	default:
 		logger.Errorf("Protocol %d not supported", protocol)
 		return ExitSetupFailed

--- a/tun/netstack/tun.go
+++ b/tun/netstack/tun.go
@@ -53,6 +53,10 @@ type netTun struct {
 type Net netTun
 
 func CreateNetTUN(localAddresses, dnsServers []netip.Addr, mtu int) (tun.Device, *Net, error) {
+	return CreateNetTUNWithCC(localAddresses, dnsServers, mtu, "")
+}
+
+func CreateNetTUNWithCC(localAddresses, dnsServers []netip.Addr, mtu int, cc string) (tun.Device, *Net, error) {
 	opts := stack.Options{
 		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol, ipv6.NewProtocol},
 		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol, udp.NewProtocol, icmp.NewProtocol6, icmp.NewProtocol4},
@@ -70,6 +74,13 @@ func CreateNetTUN(localAddresses, dnsServers []netip.Addr, mtu int) (tun.Device,
 	tcpipErr := dev.stack.SetTransportProtocolOption(tcp.ProtocolNumber, &sackEnabledOpt)
 	if tcpipErr != nil {
 		return nil, nil, fmt.Errorf("could not enable TCP SACK: %v", tcpipErr)
+	}
+	if cc != "" {
+		ccOpt := tcpip.CongestionControlOption(cc)
+		tcpipErr = dev.stack.SetTransportProtocolOption(tcp.ProtocolNumber, &ccOpt)
+		if tcpipErr != nil {
+			return nil, nil, fmt.Errorf("could not set TCP congestion control to %q: %v", cc, tcpipErr)
+		}
 	}
 	dev.notifyHandle = dev.ep.AddNotify(dev)
 	tcpipErr = dev.stack.CreateNIC(1, dev.ep)


### PR DESCRIPTION
**Kernel TUN mode (`conn/bind_tcp`):**
- Add `SetCongestionControl(cc string)` to `TcpBind`.
- On Linux, set `TCP_CONGESTION` via `net.ListenConfig.Control` (listener) and `net.Dialer.Control` (dialed conns). No-op on other platforms for now.
- Fix `Open` to return the actual bound port instead of the requested port (matters when `port == 0`).

**Netstack mode (`tun/netstack`):**
- Add `CreateNetTUNWithCC` so the gVisor userspace TCP stack's default congestion control algorithm can be set (e.g. `"cubic"` or `"reno"`). This affects tunneled TCP flows inside SOCKS5/netstack mode.
- **Note:** The current gVisor version only supports `reno` and `cubic`; `bbr` is not yet available.

**libwg API change:**
- `startWg` signature: `startWg(logLevel, protocol, interfaceName, congestionControl)`
- `startWgNetstack` signature: `startWgNetstack(logLevel, protocol, addresses, dnsServers, socksListen, socksUser, socksPass, congestionControl, mtu)`
- The new `congestionControl` parameter is a C string (e.g. `"bbr"`, `"cubic"`). It is ignored when `protocol == 0` (UDP).
